### PR TITLE
[Test] Pi Backplane

### DIFF
--- a/pcbs/python-testing/pi_backplane.py
+++ b/pcbs/python-testing/pi_backplane.py
@@ -24,6 +24,7 @@ class _Output:
 
         self._enables = dict(A=8, B=3, C=5, Cycle=10, Instruction=7, Clock=11, Reset=12)
 
+        # Define where things are in the shift register bank
         self._buses = dict(
             A=[48 + i for i in range(BUS_WIDTH)],
             B=[32 + i for i in range(BUS_WIDTH)],
@@ -31,6 +32,8 @@ class _Output:
             Instruction=[0 + i for i in range(BUS_WIDTH)],
         )
         self._cycle = [64 + i for i in reversed(range(CYCLE_WIDTH))]
+        self._clock = 77
+        self._reset = 78
 
         # Now start the GPIO bits
         GPIO.setmode(GPIO.BOARD)
@@ -86,6 +89,12 @@ class _Output:
         if step >= 0:
             self._outputs[self._cycle[step]] = True
 
+    def set_clock(self, value: bool):
+        self._outputs[self._clock] = value
+
+    def set_reset(self, value: bool):
+        self._outputs[self._reset] = value
+
 
 class _Input:
     def __init__(self):
@@ -94,6 +103,8 @@ class _Input:
         self._inputs = [False for _ in range(self.n_pins)]
         self._bus_starts = dict(A=16, B=32, C=48, Instruction=64)
         self._cycle_start = 8
+        self._clock = 6
+        self._reset = 5
 
         # Designate the pins
         self._clk_in = 40
@@ -140,3 +151,9 @@ class _Input:
                 assert step < 0, "Two steps set!"
                 step = i
         return step
+
+    def read_clock(self) -> bool:
+        return self._inputs[self._clock]
+
+    def read_reset(self) -> bool:
+        return self._inputs[self._reset]

--- a/pcbs/python-testing/pi_backplane.py
+++ b/pcbs/python-testing/pi_backplane.py
@@ -32,7 +32,10 @@ class _Output:
             )
 
         self._buses = dict(
-            A=[16 + i for i in range(BUS_WIDTH)]
+            A=[48 + i for i in range(BUS_WIDTH)],
+            B=[32 + i for i in range(BUS_WIDTH)],
+            C=[16+i for i in range(BUS_WIDTH)],
+            Instruction=[0+i for i in range(BUS_WIDTH)],
             )
 
         # Now start the GPIO bits
@@ -75,7 +78,20 @@ class _Output:
 
         for i in range(BUS_WIDTH):
             bus_idx = self._buses[target][i]
-            self._outputs[bus_idx] = send_values[i]
+            self._outputs[bus_idx] = send_values[BUS_WIDTH-i-1]
 
         self._send()
         
+# Temporary for testing
+
+output = _Output()
+output.set_oe("A", False)
+output.set_oe("B", False)
+output.set_oe("C", False)
+output.set_oe("Instruction", False)
+output.set_oe("Cycle", False)
+
+output.set_bus("A", 127)
+output.set_bus("B", 1024)
+output.set_bus("C", 4099)
+output.set_bus("Instruction", 65535)

--- a/pcbs/python-testing/pi_backplane.py
+++ b/pcbs/python-testing/pi_backplane.py
@@ -48,7 +48,7 @@ class _Output:
             GPIO.setup(p, GPIO.OUT)
             GPIO.output(p, GPIO.HIGH)
 
-    def _send(self):
+    def send(self):
         # Prepare to send
         GPIO.output(self._select_out, GPIO.LOW)
         for op in self._outputs:
@@ -74,8 +74,6 @@ class _Output:
             bus_idx = self._buses[target][i]
             self._outputs[bus_idx] = send_values[BUS_WIDTH - i - 1]
 
-        self._send()
-
     def set_cycle(self, step: int):
         # Negative values mean 'turn all off'
         assert step < CYCLE_WIDTH
@@ -87,8 +85,6 @@ class _Output:
         # Turn on desired step
         if step >= 0:
             self._outputs[self._cycle[step]] = True
-
-        self._send()
 
 
 class _Input:
@@ -144,35 +140,3 @@ class _Input:
                 assert step < 0, "Two steps set!"
                 step = i
         return step
-
-
-# Temporary for testing
-
-output = _Output()
-input = _Input()
-
-output.set_oe("A", False)
-output.set_oe("B", False)
-output.set_oe("C", False)
-output.set_oe("Instruction", False)
-output.set_oe("Cycle", False)
-
-import time
-
-start = time.time()
-output.set_bus("A", 21931)
-output.set_bus("B", 5036)
-output.set_bus("C", 345)
-output.set_bus("Instruction", 27)
-stop = time.time()
-print(f"{stop-start} secs to send")
-
-output.set_cycle(4)
-
-
-input.recv()
-print(input.read_bus("A"))
-print(input.read_bus("B"))
-print(input.read_bus("C"))
-print(input.read_bus("Instruction"))
-print(input.read_cycle())

--- a/pcbs/python-testing/pi_backplane.py
+++ b/pcbs/python-testing/pi_backplane.py
@@ -37,6 +37,8 @@ class _Output:
             C=[16+i for i in range(BUS_WIDTH)],
             Instruction=[0+i for i in range(BUS_WIDTH)],
             )
+        self._cycle = [64 + i for i in reversed(range(CYCLE_WIDTH))]
+        
 
         # Now start the GPIO bits
         GPIO.setmode(GPIO.BOARD)
@@ -81,6 +83,20 @@ class _Output:
             self._outputs[bus_idx] = send_values[BUS_WIDTH-i-1]
 
         self._send()
+
+    def set_cycle(self, step: int):
+        # Negative values mean 'turn all off'
+        assert step < CYCLE_WIDTH
+
+        # Ensure everything is off
+        for i in range(CYCLE_WIDTH):
+            self._outputs[self._cycle[i]] = False
+
+        # Turn on desired step
+        if step >= 0:
+            self._outputs[self._cycle[step]] = True
+
+        self._send()
         
 # Temporary for testing
 
@@ -91,7 +107,14 @@ output.set_oe("C", False)
 output.set_oe("Instruction", False)
 output.set_oe("Cycle", False)
 
-output.set_bus("A", 127)
-output.set_bus("B", 1024)
-output.set_bus("C", 4099)
-output.set_bus("Instruction", 65535)
+import time
+
+start = time.time()
+output.set_bus("A", 0)
+output.set_bus("B", 0)
+output.set_bus("C", 0)
+output.set_bus("Instruction", 0)
+stop = time.time()
+print(f"{stop-start} secs to send")
+
+output.set_cycle(4)

--- a/pcbs/python-testing/pi_backplane.py
+++ b/pcbs/python-testing/pi_backplane.py
@@ -1,0 +1,81 @@
+from typing import List, Union
+
+import bitarray
+import bitarray.util
+
+import RPi.GPIO as GPIO
+
+BUS_WIDTH = 16
+CYCLE_WIDTH = 5
+
+class _Output:
+    def __init__(self):
+        self.n_pins = 80
+
+        self._outputs = [False for _ in range(self.n_pins)]
+
+        # SPI bus clock (SRCLK)
+        self._clk_out = 23
+        # SPI bus data (DATA)
+        self._copi = 19
+        # SPI bus select (RCLK)
+        self._select_out = 24
+
+        self._enables = dict(
+            A = 8,
+            B = 3,
+            C = 5,
+            Cycle = 10,
+            Instruction = 7,
+            Clock = 11,
+            Reset = 12
+            )
+
+        self._buses = dict(
+            A=[16 + i for i in range(BUS_WIDTH)]
+            )
+
+        # Now start the GPIO bits
+        GPIO.setmode(GPIO.BOARD)
+
+        # Set up SPI basics
+        GPIO.setup(self._clk_out, GPIO.OUT)
+        GPIO.output(self._clk_out, GPIO.LOW)
+        GPIO.setup(self._copi, GPIO.OUT)
+        GPIO.setup(self._copi, GPIO.LOW)
+        GPIO.setup(self._select_out, GPIO.OUT)
+        GPIO.output(self._select_out, GPIO.HIGH)
+
+        # Now the enables
+        for p in self._enables.values():
+            GPIO.setup(p, GPIO.OUT)
+            GPIO.output(p, GPIO.HIGH)
+            
+    def _send(self):
+        # Prepare to send
+        GPIO.output(self._select_out, GPIO.LOW)
+        for op in self._outputs:
+            GPIO.output(self._copi, op)
+            GPIO.output(self._clk_out, GPIO.LOW)
+            GPIO.output(self._clk_out, GPIO.HIGH)
+        # Clock everything into output stages
+        GPIO.output(self._select_out, GPIO.HIGH)
+        # Idle clk_out low
+        GPIO.output(self._clk_out, GPIO.LOW)
+            
+    def set_oe(self, target: str, value: bool):
+        GPIO.output(self._enables[target], value)
+
+    def set_bus(self, target: str, value: Union[int, bitarray.bitarray]):
+        if isinstance(value, int):
+            assert value >=0 and value < 2**BUS_WIDTH
+            send_values = bitarray.util.int2ba(value, length=BUS_WIDTH, endian="little")
+        else:
+            send_values = value
+
+        for i in range(BUS_WIDTH):
+            bus_idx = self._buses[target][i]
+            self._outputs[bus_idx] = send_values[i]
+
+        self._send()
+        

--- a/pcbs/python-testing/test_pi_backplane.py
+++ b/pcbs/python-testing/test_pi_backplane.py
@@ -60,3 +60,57 @@ def test_buses(A, B, C, Instruction, Cycle):
     assert input.read_bus("C") == C
     assert input.read_bus("Instruction") == Instruction
     assert input.read_cycle() == -1
+
+
+def test_clock():
+    output = _Output()
+    input = _Input()
+
+    output.set_oe("Clock", False)
+
+    output.set_clock(True)
+    output.send()
+    input.recv()
+    assert input.read_clock() == True
+
+    output.set_clock(False)
+    output.send()
+    input.recv()
+    assert input.read_clock() == False
+
+    output.set_clock(True)
+    output.send()
+    input.recv()
+    assert input.read_clock() == True
+
+    # Should be pulled down by LED on isolation
+    output.set_oe("Clock", True)
+    input.recv()
+    assert input.read_clock() == False
+
+
+def test_reset():
+    output = _Output()
+    input = _Input()
+
+    output.set_oe("Reset", False)
+
+    output.set_reset(True)
+    output.send()
+    input.recv()
+    assert input.read_reset() == True
+
+    output.set_reset(False)
+    output.send()
+    input.recv()
+    assert input.read_reset() == False
+
+    output.set_reset(True)
+    output.send()
+    input.recv()
+    assert input.read_reset() == True
+
+    # Should be pulled down by LED on isolation
+    output.set_oe("Reset", True)
+    input.recv()
+    assert input.read_clock() == False

--- a/pcbs/python-testing/test_pi_backplane.py
+++ b/pcbs/python-testing/test_pi_backplane.py
@@ -1,0 +1,62 @@
+import pytest
+
+from pi_backplane import _Input, _Output
+
+bus_vals = [0, 1, 32768, 45534, 65535]
+cycle_vals = list(range(-1, 5))
+
+
+@pytest.mark.parametrize("A", bus_vals)
+@pytest.mark.parametrize("B", bus_vals)
+@pytest.mark.parametrize("C", bus_vals)
+@pytest.mark.parametrize("Instruction", bus_vals)
+@pytest.mark.parametrize("Cycle", cycle_vals)
+def test_buses(A, B, C, Instruction, Cycle):
+    output = _Output()
+    input = _Input()
+
+    buses = ["A", "B", "C", "Instruction"]
+    for bus in buses:
+        output.set_oe(bus, False)
+    output.set_oe("Cycle", False)
+
+    output.set_bus("A", A)
+    output.set_bus("B", B)
+    output.set_bus("C", C)
+    output.set_bus("Instruction", Instruction)
+    output.set_cycle(Cycle)
+    output.send()
+
+    input.recv()
+    assert input.read_bus("A") == A
+    assert input.read_bus("B") == B
+    assert input.read_bus("C") == C
+    assert input.read_bus("Instruction") == Instruction
+    assert input.read_cycle() == Cycle
+
+    # Now isolate individual buses
+    for target_bus in buses:
+        for b in buses:
+            output.set_oe(b, False)
+        output.set_oe(target_bus, True)
+
+        input.recv()
+        assert input.read_bus("A") == (A if target_bus != "A" else 0)
+        assert input.read_bus("B") == (B if target_bus != "B" else 0)
+        assert input.read_bus("C") == (C if target_bus != "C" else 0)
+        assert input.read_bus("Instruction") == (
+            Instruction if target_bus != "Instruction" else 0
+        )
+        assert input.read_cycle() == Cycle
+
+    # And the cycle bus
+    for bus in buses:
+        output.set_oe(bus, False)
+    output.set_oe("Cycle", True)
+
+    input.recv()
+    assert input.read_bus("A") == A
+    assert input.read_bus("B") == B
+    assert input.read_bus("C") == C
+    assert input.read_bus("Instruction") == Instruction
+    assert input.read_cycle() == -1


### PR DESCRIPTION
Add a class for handling the Pi Backplane Connector board (in the `python-testing` directory for now), along with a test file (since the point of the board is that outputs also have connections to inputs).

The re-ordering going on with the input registers is.... quite something.